### PR TITLE
feat: scaffold modular compliant crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+.pytest_cache/
+.cache/
+*.pyc
+.env
+.venv/
+data/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# PythonWebCrawler
-Development of Python Web Crawler 
+# Legal, Modular Python Web Crawler
+
+This project provides a policy-compliant, modular crawling framework for aggregating:
+
+- Public documents from vetted sources (e.g., Internet Archive, government open data portals)
+- Free-to-watch movies via official metadata APIs
+- Product pricing from retailer APIs that allow aggregation
+
+The architecture emphasizes compliance with robots.txt, rate limits, and terms of service. Each data source is implemented as an adapter that encapsulates discovery, fetching, and parsing logic.
+
+## Features
+
+- **Async HTTP client** with caching, robots.txt enforcement, exponential backoff, and per-domain rate limiting
+- **Pydantic models** that normalize results into a consistent schema
+- **Modular adapter system** for extending supported sources without modifying the core pipeline
+- **Audit logging** for requests, including adapter decisions and payload sizes
+- **Storage utilities** to persist results in JSONL and SQLite formats
+- **CLI** powered by Typer for running crawls from the command line
+- **Configuration system** using YAML/Pydantic with environment overrides
+
+## Getting Started
+
+1. Create and activate a Python 3.11+ virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+3. Create a `config.yaml` (optional) to override defaults such as API keys, adapter options, and output paths.
+4. Run the crawler:
+
+   ```bash
+   python -m crawler.cli crawl --kind docs --query "machine learning" --max-results 100
+   ```
+
+Results are written to the configured JSONL and SQLite outputs. Audit logs and HTTP caches live under `.cache/` by default.
+
+## Testing
+
+Execute the test suite with:
+
+```bash
+pytest
+```
+
+Network calls are mocked in tests; live HTTP smoke tests can be added and toggled via environment flags when needed.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,26 @@
+user_agent: "LegalCrawler/1.0 (+contact@example.com)"
+cache_dir: ".cache"
+concurrency:
+  global_max_tasks: 20
+  per_domain_rps: 1.5
+adapters:
+  - name: internet_archive_docs
+    options: {}
+  - name: gov_open_data
+    options:
+      base_url: "https://catalog.data.gov/api/3/action"
+  - name: tmdb_free
+    options:
+      api_key: "${TMDB_API_KEY}"
+  - name: youtube_free
+    options:
+      api_key: "${YOUTUBE_API_KEY}"
+  - name: retailer_api_example
+    options:
+      api_endpoint: "https://api.example.com/products"
+filters:
+  language: ["en", "de"]
+  min_year: 1920
+output:
+  sqlite_path: "data/results.db"
+  jsonl_path: "data/results.jsonl"

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -1,0 +1,8 @@
+"""Top-level package for the modular, policy-compliant web crawler."""
+
+from .settings import AppSettings, load_settings
+from .cli import app
+from .core.models import Record
+from .core.pipeline import crawl
+
+__all__ = ["AppSettings", "Record", "load_settings", "crawl", "app"]

--- a/crawler/adapters/base.py
+++ b/crawler/adapters/base.py
@@ -1,0 +1,33 @@
+"""Base definitions for crawler adapters."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any, Iterable, List
+
+from ..core.models import Kind, Record
+
+
+class BaseAdapter(abc.ABC):
+    """Abstract base class describing adapter contract."""
+
+    name: str
+    kinds: Iterable[Kind]
+
+    def __init__(self, *, settings: dict | None = None) -> None:
+        self.settings = settings or {}
+
+    @abc.abstractmethod
+    async def discover(self, query: str) -> List[str]:
+        """Return candidate URLs for the given query."""
+
+    @abc.abstractmethod
+    async def fetch(self, url: str) -> Any:
+        """Fetch raw data for the URL."""
+
+    @abc.abstractmethod
+    async def parse(self, raw: Any) -> List[Record]:
+        """Parse raw data into normalized records."""
+
+    def supports_kind(self, kind: Kind) -> bool:
+        return kind in self.kinds or kind is Kind.ALL

--- a/crawler/adapters/gov_open_data.py
+++ b/crawler/adapters/gov_open_data.py
@@ -1,0 +1,88 @@
+"""Adapter for CKAN-based government open data portals."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core.http import AsyncHttpClient
+from ..core.models import Kind, Record
+from ..core.utils import stable_hash
+from .base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class Adapter(BaseAdapter):
+    name = "gov_open_data"
+    kinds = (Kind.DOCUMENT,)
+
+    def __init__(self, *, settings: Dict[str, Any] | None = None) -> None:
+        super().__init__(settings=settings)
+        app_settings = self.settings.get("app_settings")
+        if app_settings is None:
+            raise ValueError("App settings are required")
+        self.app_settings = app_settings
+        self.base_url = self.settings.get("base_url", "https://catalog.data.gov/api/3/action")
+        self.cache_dir = Path(app_settings.cache_dir) / self.name
+        self.audit_path = Path(app_settings.cache_dir) / "audit.log"
+
+    def _client(self) -> AsyncHttpClient:
+        return AsyncHttpClient(
+            user_agent=self.app_settings.user_agent,
+            cache_dir=self.cache_dir,
+            per_domain_limit=self.app_settings.concurrency.per_domain_rps,
+            audit_path=self.audit_path,
+            adapter_name=self.name,
+        )
+
+    async def discover(self, query: str) -> List[str]:
+        url = f"{self.base_url}/package_search"
+        params = {"q": query, "rows": 50}
+        async with self._client() as http:
+            response = await http.get(url, params=params)
+        data = response.json()
+        results = data.get("result", {}).get("results", [])
+        return [result["id"] for result in results]
+
+    async def fetch(self, package_id: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/package_show"
+        params = {"id": package_id}
+        async with self._client() as http:
+            response = await http.get(url, params=params)
+        return response.json()
+
+    async def parse(self, raw: Dict[str, Any]) -> List[Record]:
+        result = raw.get("result")
+        if not result:
+            return []
+        resources = result.get("resources", [])
+        records: List[Record] = []
+        for resource in resources:
+            if resource.get("state") != "active":
+                continue
+            source_url = resource.get("url")
+            if not source_url:
+                continue
+            record = Record(
+                id=stable_hash({"provider": self.name, "resource_id": resource.get("id")}),
+                kind=Kind.DOCUMENT,
+                title=resource.get("name") or result.get("title"),
+                description=result.get("notes"),
+                creators=[org.get("title")] if (org := result.get("organization")) else None,
+                year=None,
+                language=None,
+                topics=[tag["name"] for tag in result.get("tags", [])],
+                provider=self.name,
+                source_url=source_url,
+                license=result.get("license_url") or result.get("license_title"),
+                media={"type": "page", "format": resource.get("format")},
+                availability={"is_free": True, "regions": None, "expires_at": None},
+                price={},
+                extra={"raw": resource},
+                ingested_at=datetime.utcnow(),
+            )
+            records.append(record)
+        return records

--- a/crawler/adapters/gov_open_data_terms.md
+++ b/crawler/adapters/gov_open_data_terms.md
@@ -1,0 +1,5 @@
+# Government Open Data (CKAN)
+
+- Robots: Refer to specific CKAN portal (default https://catalog.data.gov/robots.txt).
+- Terms: https://catalog.data.gov/dataset for dataset-specific licensing.
+- Notes: Access only publicly available datasets and respect API usage guidance.

--- a/crawler/adapters/internet_archive_docs.py
+++ b/crawler/adapters/internet_archive_docs.py
@@ -1,0 +1,82 @@
+"""Adapter for the Internet Archive documents API."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core.http import AsyncHttpClient
+from ..core.models import Kind, Record
+from ..core.utils import stable_hash
+from .base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class Adapter(BaseAdapter):
+    name = "internet_archive_docs"
+    kinds = (Kind.DOCUMENT,)
+
+    def __init__(self, *, settings: Dict[str, Any] | None = None) -> None:
+        super().__init__(settings=settings)
+        app_settings = self.settings.get("app_settings")
+        if app_settings is None:
+            raise ValueError("App settings are required")
+        self.app_settings = app_settings
+        self.cache_dir = Path(app_settings.cache_dir) / self.name
+        self.audit_path = Path(app_settings.cache_dir) / "audit.log"
+
+    def _client(self) -> AsyncHttpClient:
+        return AsyncHttpClient(
+            user_agent=self.app_settings.user_agent,
+            cache_dir=self.cache_dir,
+            per_domain_limit=self.app_settings.concurrency.per_domain_rps,
+            audit_path=self.audit_path,
+            adapter_name=self.name,
+        )
+
+    async def discover(self, query: str) -> List[str]:
+        params = {
+            "q": query,
+            "fl[]": ["identifier", "title", "creator", "description", "language", "year"],
+            "rows": 50,
+            "output": "json",
+        }
+        async with self._client() as http:
+            response = await http.get("https://archive.org/advancedsearch.php", params=params)
+        data = response.json()
+        docs = data.get("response", {}).get("docs", [])
+        return [doc["identifier"] for doc in docs]
+
+    async def fetch(self, identifier: str) -> Dict[str, Any]:
+        url = f"https://archive.org/metadata/{identifier}"
+        async with self._client() as http:
+            response = await http.get(url)
+        return response.json()
+
+    async def parse(self, raw: Dict[str, Any]) -> List[Record]:
+        metadata = raw.get("metadata", {})
+        identifier = metadata.get("identifier")
+        if not identifier:
+            return []
+        record = Record(
+            id=stable_hash({"provider": self.name, "identifier": identifier}),
+            kind=Kind.DOCUMENT,
+            title=metadata.get("title", identifier),
+            description=metadata.get("description"),
+            creators=[metadata.get("creator")] if metadata.get("creator") else None,
+            year=int(metadata["year"]) if metadata.get("year") else None,
+            language=metadata.get("language"),
+            topics=metadata.get("subject"),
+            provider=self.name,
+            source_url=f"https://archive.org/details/{identifier}",
+            license=metadata.get("licenseurl") or metadata.get("rights"),
+            media={"type": "pdf", "format": metadata.get("format")},
+            availability={"is_free": True, "regions": None, "expires_at": None},
+            price={},
+            extra={"raw": metadata},
+            ingested_at=datetime.utcnow(),
+        )
+        return [record]

--- a/crawler/adapters/internet_archive_docs_terms.md
+++ b/crawler/adapters/internet_archive_docs_terms.md
@@ -1,0 +1,5 @@
+# Internet Archive Documents
+
+- Robots: https://archive.org/robots.txt
+- Terms: https://archive.org/about/terms.php
+- Notes: Use advanced search and metadata APIs only. Respect rate limits (1 req/sec recommended).

--- a/crawler/adapters/retailer_api_example.py
+++ b/crawler/adapters/retailer_api_example.py
@@ -1,0 +1,85 @@
+"""Example adapter for retailer pricing via official API or feed."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core.http import AsyncHttpClient
+from ..core.models import Kind, Record
+from ..core.utils import stable_hash
+from .base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class Adapter(BaseAdapter):
+    name = "retailer_api_example"
+    kinds = (Kind.PRICE,)
+
+    def __init__(self, *, settings: Dict[str, Any] | None = None) -> None:
+        super().__init__(settings=settings)
+        app_settings = self.settings.get("app_settings")
+        if app_settings is None:
+            raise ValueError("App settings are required")
+        self.app_settings = app_settings
+        self.api_endpoint = self.settings.get("api_endpoint")
+        if not self.api_endpoint:
+            raise ValueError("api_endpoint must be configured for retailer adapter")
+        self.cache_dir = Path(app_settings.cache_dir) / self.name
+        self.audit_path = Path(app_settings.cache_dir) / "audit.log"
+
+    def _client(self) -> AsyncHttpClient:
+        return AsyncHttpClient(
+            user_agent=self.app_settings.user_agent,
+            cache_dir=self.cache_dir,
+            per_domain_limit=self.app_settings.concurrency.per_domain_rps,
+            audit_path=self.audit_path,
+            adapter_name=self.name,
+        )
+
+    async def discover(self, query: str) -> List[str]:
+        # For official APIs we assume search endpoint is provided.
+        params = {"q": query, "limit": 50}
+        async with self._client() as http:
+            response = await http.get(self.api_endpoint, params=params)
+        data = response.json()
+        items = data.get("items", [])
+        return [item.get("id") for item in items if item.get("id")]
+
+    async def fetch(self, item_id: str) -> Dict[str, Any]:
+        url = f"{self.api_endpoint.rstrip('/')}/{item_id}"
+        async with self._client() as http:
+            response = await http.get(url)
+        return response.json()
+
+    async def parse(self, raw: Dict[str, Any]) -> List[Record]:
+        if not raw:
+            return []
+        record = Record(
+            id=stable_hash({"provider": self.name, "sku": raw.get("sku") or raw.get("id")}),
+            kind=Kind.PRICE,
+            title=raw.get("title") or raw.get("name"),
+            description=raw.get("description"),
+            creators=None,
+            year=None,
+            language=None,
+            topics=raw.get("categories"),
+            provider=self.name,
+            source_url=raw.get("url"),
+            license=raw.get("license"),
+            media={"type": "product", "format": "json"},
+            availability={"is_free": False, "regions": raw.get("regions"), "expires_at": None},
+            price={
+                "currency": raw.get("currency"),
+                "amount": raw.get("price"),
+                "sku": raw.get("sku"),
+                "retailer": raw.get("retailer"),
+                "collected_at": datetime.utcnow().isoformat(),
+            },
+            extra={"raw": raw},
+            ingested_at=datetime.utcnow(),
+        )
+        return [record]

--- a/crawler/adapters/retailer_api_example_terms.md
+++ b/crawler/adapters/retailer_api_example_terms.md
@@ -1,0 +1,5 @@
+# Retailer API Example
+
+- Robots: Refer to retailer developer portal robots.txt.
+- Terms: Use only official API endpoints documented by the retailer. Comply with their ToS and rate limits.
+- Notes: Requires configured API endpoint that explicitly allows price aggregation.

--- a/crawler/adapters/tmdb_free.py
+++ b/crawler/adapters/tmdb_free.py
@@ -1,0 +1,88 @@
+"""Adapter for TMDB free-to-watch metadata."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core.http import AsyncHttpClient
+from ..core.models import Kind, Record
+from ..core.utils import stable_hash
+from .base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class Adapter(BaseAdapter):
+    name = "tmdb_free"
+    kinds = (Kind.MOVIE,)
+
+    def __init__(self, *, settings: Dict[str, Any] | None = None) -> None:
+        super().__init__(settings=settings)
+        app_settings = self.settings.get("app_settings")
+        if app_settings is None:
+            raise ValueError("App settings are required")
+        self.app_settings = app_settings
+        self.api_key = self.settings.get("api_key") or os.getenv("TMDB_API_KEY")
+        if not self.api_key:
+            raise ValueError("TMDB API key must be provided via settings or TMDB_API_KEY env")
+        self.cache_dir = Path(app_settings.cache_dir) / self.name
+        self.audit_path = Path(app_settings.cache_dir) / "audit.log"
+
+    def _client(self) -> AsyncHttpClient:
+        return AsyncHttpClient(
+            user_agent=self.app_settings.user_agent,
+            cache_dir=self.cache_dir,
+            per_domain_limit=self.app_settings.concurrency.per_domain_rps,
+            audit_path=self.audit_path,
+            adapter_name=self.name,
+        )
+
+    async def discover(self, query: str) -> List[int]:
+        url = "https://api.themoviedb.org/3/search/movie"
+        params = {"query": query, "api_key": self.api_key, "include_adult": False}
+        async with self._client() as http:
+            response = await http.get(url, params=params)
+        data = response.json()
+        results = data.get("results", [])
+        return [result["id"] for result in results]
+
+    async def fetch(self, movie_id: int) -> Dict[str, Any]:
+        url = f"https://api.themoviedb.org/3/movie/{movie_id}"
+        params = {"api_key": self.api_key, "append_to_response": "watch/providers"}
+        async with self._client() as http:
+            response = await http.get(url, params=params)
+        return response.json()
+
+    async def parse(self, raw: Dict[str, Any]) -> List[Record]:
+        providers = raw.get("watch/providers", {}).get("results", {})
+        free_regions = []
+        for region, info in providers.items():
+            flatrate = info.get("flatrate", [])
+            ads = info.get("ads", [])
+            if flatrate or ads:
+                free_regions.append(region)
+        if not free_regions:
+            return []
+        record = Record(
+            id=stable_hash({"provider": self.name, "tmdb_id": raw.get("id")}),
+            kind=Kind.MOVIE,
+            title=raw.get("title"),
+            description=raw.get("overview"),
+            creators=None,
+            year=int(raw["release_date"].split("-")[0]) if raw.get("release_date") else None,
+            language=raw.get("original_language"),
+            topics=[genre.get("name") for genre in raw.get("genres", [])],
+            provider=self.name,
+            source_url=f"https://www.themoviedb.org/movie/{raw.get('id')}",
+            license=None,
+            media={"type": "video", "duration_sec": raw.get("runtime", 0) * 60, "format": "video"},
+            availability={"is_free": True, "regions": free_regions, "expires_at": None},
+            price={},
+            extra={"raw": raw},
+            ingested_at=datetime.utcnow(),
+        )
+        return [record]

--- a/crawler/adapters/tmdb_free_terms.md
+++ b/crawler/adapters/tmdb_free_terms.md
@@ -1,0 +1,5 @@
+# TMDB Free-to-Watch Metadata
+
+- Robots: https://www.themoviedb.org/robots.txt
+- Terms: https://www.themoviedb.org/documentation/terms-of-use
+- Notes: Requires API key; use watch/providers endpoint to confirm free availability. Abide by request limits.

--- a/crawler/adapters/youtube_free.py
+++ b/crawler/adapters/youtube_free.py
@@ -1,0 +1,119 @@
+"""Adapter for YouTube Data API focusing on Creative Commons/free movies."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..core.http import AsyncHttpClient
+from ..core.models import Kind, Record
+from ..core.utils import stable_hash
+from .base import BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class Adapter(BaseAdapter):
+    name = "youtube_free"
+    kinds = (Kind.MOVIE,)
+
+    def __init__(self, *, settings: Dict[str, Any] | None = None) -> None:
+        super().__init__(settings=settings)
+        app_settings = self.settings.get("app_settings")
+        if app_settings is None:
+            raise ValueError("App settings are required")
+        self.app_settings = app_settings
+        self.api_key = self.settings.get("api_key") or os.getenv("YOUTUBE_API_KEY")
+        if not self.api_key:
+            raise ValueError("YouTube API key must be provided via settings or YOUTUBE_API_KEY env")
+        self.cache_dir = Path(app_settings.cache_dir) / self.name
+        self.audit_path = Path(app_settings.cache_dir) / "audit.log"
+
+    def _client(self) -> AsyncHttpClient:
+        return AsyncHttpClient(
+            user_agent=self.app_settings.user_agent,
+            cache_dir=self.cache_dir,
+            per_domain_limit=self.app_settings.concurrency.per_domain_rps,
+            audit_path=self.audit_path,
+            adapter_name=self.name,
+        )
+
+    async def discover(self, query: str) -> List[str]:
+        url = "https://www.googleapis.com/youtube/v3/search"
+        params = {
+            "q": query,
+            "key": self.api_key,
+            "part": "snippet",
+            "type": "video",
+            "videoDuration": "long",
+            "videoLicense": "creativeCommon",
+            "maxResults": 25,
+        }
+        async with self._client() as http:
+            response = await http.get(url, params=params)
+        data = response.json()
+        items = data.get("items", [])
+        return [item["id"]["videoId"] for item in items]
+
+    async def fetch(self, video_id: str) -> Dict[str, Any]:
+        url = "https://www.googleapis.com/youtube/v3/videos"
+        params = {
+            "id": video_id,
+            "part": "snippet,contentDetails,topicDetails",
+            "key": self.api_key,
+        }
+        async with self._client() as http:
+            response = await http.get(url, params=params)
+        data = response.json()
+        items = data.get("items", [])
+        return items[0] if items else {}
+
+    async def parse(self, raw: Dict[str, Any]) -> List[Record]:
+        if not raw:
+            return []
+        snippet = raw.get("snippet", {})
+        content_details = raw.get("contentDetails", {})
+        duration = _parse_iso_duration(content_details.get("duration"))
+        record = Record(
+            id=stable_hash({"provider": self.name, "video_id": raw.get("id")}),
+            kind=Kind.MOVIE,
+            title=snippet.get("title"),
+            description=snippet.get("description"),
+            creators=[snippet.get("channelTitle")] if snippet.get("channelTitle") else None,
+            year=int(snippet["publishedAt"][:4]) if snippet.get("publishedAt") else None,
+            language=None,
+            topics=raw.get("topicDetails", {}).get("topicCategories"),
+            provider=self.name,
+            source_url=f"https://www.youtube.com/watch?v={raw.get('id')}",
+            license="Creative Commons",
+            media={"type": "video", "duration_sec": duration, "format": "mp4"},
+            availability={"is_free": True, "regions": None, "expires_at": None},
+            price={},
+            extra={"raw": raw},
+            ingested_at=datetime.utcnow(),
+        )
+        return [record]
+
+
+def _parse_iso_duration(value: str | None) -> int:
+    if not value:
+        return 0
+    # Minimal ISO8601 duration parser for PT#H#M#S
+    hours = minutes = seconds = 0
+    value = value.replace("PT", "")
+    number = ""
+    for char in value:
+        if char.isdigit():
+            number += char
+        else:
+            if char == "H":
+                hours = int(number)
+            elif char == "M":
+                minutes = int(number)
+            elif char == "S":
+                seconds = int(number)
+            number = ""
+    return hours * 3600 + minutes * 60 + seconds

--- a/crawler/adapters/youtube_free_terms.md
+++ b/crawler/adapters/youtube_free_terms.md
@@ -1,0 +1,5 @@
+# YouTube Creative Commons Catalog
+
+- Robots: https://www.youtube.com/robots.txt
+- Terms: https://developers.google.com/youtube/terms/api-services-terms-of-service
+- Notes: Use YouTube Data API v3 with videoLicense=creativeCommon. No downloading or playback scraping.

--- a/crawler/cli.py
+++ b/crawler/cli.py
@@ -1,0 +1,43 @@
+"""Command line interface for the web crawler."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .core.pipeline import crawl
+from .settings import AppSettings, load_settings
+from .core.storage import ResultWriter
+from .core.models import Kind
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+@app.command()
+def crawl_command(
+    kind: Kind = typer.Option(..., "--kind", case_sensitive=False, help="Type of content to crawl."),
+    query: str = typer.Option(..., "--query", help="Search query."),
+    max_results: int = typer.Option(200, "--max-results", help="Maximum results to collect."),
+    out: Path = typer.Option(Path("data/results.jsonl"), "--out", help="Path to output JSONL file."),
+    config: Optional[Path] = typer.Option(None, "--config", help="Path to configuration YAML file."),
+) -> None:
+    """Entry point for the crawler CLI."""
+
+    settings = load_settings(config)
+    settings = settings.model_copy(update={"output": settings.output.model_copy(update={"jsonl_path": str(out)})})
+
+    records = asyncio.run(crawl(kind=kind, query=query, limit=max_results, settings=settings))
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with ResultWriter(settings.output) as writer:
+        for record in records:
+            writer.write_record(record)
+    typer.echo(json.dumps({"count": len(records), "output": str(out)}, indent=2))
+
+
+if __name__ == "__main__":
+    app()

--- a/crawler/core/audit.py
+++ b/crawler/core/audit.py
@@ -1,0 +1,35 @@
+"""Audit logging utilities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from .models import AuditEntry
+
+
+class AuditLogger:
+    """Persists structured audit entries to disk."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(self, entry: AuditEntry) -> None:
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry.dict()) + "\n")
+
+
+def record_request(*, adapter: str, url: str, status_code: int, bytes_count: int, decision: str, path: Path) -> None:
+    logger = AuditLogger(path)
+    entry = AuditEntry(
+        timestamp=datetime.utcnow(),
+        adapter=adapter,
+        url=url,
+        status_code=status_code,
+        bytes=bytes_count,
+        decision=decision,
+    )
+    logger.log(entry)

--- a/crawler/core/http.py
+++ b/crawler/core/http.py
@@ -1,0 +1,238 @@
+"""Async HTTP utilities with caching, rate limiting, and robots awareness."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import httpx
+from aiolimiter import AsyncLimiter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CachedResponse:
+    status_code: int
+    headers: Dict[str, str]
+    content: bytes
+    timestamp: float
+
+    def to_bytes(self) -> bytes:
+        return json.dumps(
+            {
+                "status_code": self.status_code,
+                "headers": self.headers,
+                "timestamp": self.timestamp,
+                "content": self.content.decode("latin1"),
+            }
+        ).encode("utf-8")
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "CachedResponse":
+        payload = json.loads(data.decode("utf-8"))
+        return cls(
+            status_code=payload["status_code"],
+            headers={k: str(v) for k, v in payload["headers"].items()},
+            content=payload["content"].encode("latin1"),
+            timestamp=payload["timestamp"],
+        )
+
+
+class DiskCache:
+    """Simple on-disk cache keyed by URL."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path_for(self, key: str) -> Path:
+        safe = httpx.URL(key).raw_path.replace("/", "_")
+        return self.cache_dir / f"{hash(key)}_{safe}.json"
+
+    def get(self, key: str) -> Optional[CachedResponse]:
+        path = self._path_for(key)
+        if not path.exists():
+            return None
+        try:
+            return CachedResponse.from_bytes(path.read_bytes())
+        except Exception:
+            logger.exception("Failed to read cache entry for %s", key)
+            return None
+
+    def set(self, key: str, response: CachedResponse) -> None:
+        path = self._path_for(key)
+        try:
+            path.write_bytes(response.to_bytes())
+        except Exception:
+            logger.exception("Failed to write cache entry for %s", key)
+
+
+class RobotsManager:
+    """Manages per-domain robots.txt parsing."""
+
+    def __init__(self, user_agent: str, timeout: float = 10.0) -> None:
+        self.user_agent = user_agent
+        self.timeout = timeout
+        self._parsers: Dict[str, RobotFileParser] = {}
+        self._lock = asyncio.Lock()
+
+    async def allowed(self, client: httpx.AsyncClient, url: str) -> bool:
+        parsed = urlparse(url)
+        base = f"{parsed.scheme}://{parsed.netloc}"
+        async with self._lock:
+            parser = self._parsers.get(base)
+            if parser is None:
+                robots_url = f"{base}/robots.txt"
+                try:
+                    response = await client.get(robots_url, timeout=self.timeout)
+                except httpx.HTTPError:
+                    logger.warning("Failed to fetch robots.txt from %s", robots_url)
+                    parser = RobotFileParser()
+                    parser.parse([])
+                else:
+                    parser = RobotFileParser()
+                    parser.set_url(robots_url)
+                    parser.parse(response.text.splitlines())
+                self._parsers[base] = parser
+        return parser.can_fetch(self.user_agent, url)
+
+
+class RateLimiterRegistry:
+    """Registry of per-domain rate limiters."""
+
+    def __init__(self, per_domain_limit: float) -> None:
+        self.per_domain_limit = per_domain_limit
+        self._limiters: Dict[str, AsyncLimiter] = {}
+        self._lock = asyncio.Lock()
+
+    async def limiter_for(self, url: str) -> AsyncLimiter:
+        domain = httpx.URL(url).netloc
+        async with self._lock:
+            limiter = self._limiters.get(domain)
+            if limiter is None:
+                limiter = AsyncLimiter(max_rate=self.per_domain_limit, time_period=1)
+                self._limiters[domain] = limiter
+            return limiter
+
+
+class AsyncHttpClient:
+    """High-level HTTP client with caching, robots, and retry support."""
+
+    def __init__(
+        self,
+        *,
+        user_agent: str,
+        cache_dir: Path,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+        backoff_base: float = 0.5,
+        per_domain_limit: float = 2.0,
+        audit_path: Path | None = None,
+        adapter_name: str | None = None,
+    ) -> None:
+        headers = {"User-Agent": user_agent}
+        self._client = httpx.AsyncClient(headers=headers, timeout=timeout)
+        self.cache = DiskCache(cache_dir)
+        self.max_retries = max_retries
+        self.backoff_base = backoff_base
+        self.robots = RobotsManager(user_agent=user_agent)
+        self.limiters = RateLimiterRegistry(per_domain_limit)
+        self.audit_path = audit_path
+        self.adapter_name = adapter_name
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        limiter = await self.limiters.limiter_for(url)
+        async with limiter:
+            retries = 0
+            while True:
+                try:
+                    response = await self._client.request(method, url, **kwargs)
+                except httpx.HTTPError as exc:
+                    if retries >= self.max_retries:
+                        raise
+                    await asyncio.sleep(self._backoff_delay(retries))
+                    retries += 1
+                    continue
+                if response.status_code in {429, 500, 502, 503, 504} and retries < self.max_retries:
+                    await asyncio.sleep(self._backoff_delay(retries))
+                    retries += 1
+                    continue
+                return response
+
+    def _backoff_delay(self, retries: int) -> float:
+        return self.backoff_base * (2 ** retries)
+
+    async def get(self, url: str, *, use_cache: bool = True, **kwargs) -> httpx.Response:
+        if use_cache:
+            cached = self.cache.get(url)
+            if cached:
+                headers = kwargs.setdefault("headers", {})
+                if "ETag" in cached.headers:
+                    headers["If-None-Match"] = cached.headers["ETag"]
+                if "Last-Modified" in cached.headers:
+                    headers["If-Modified-Since"] = cached.headers["Last-Modified"]
+        else:
+            cached = None
+
+        if not await self.robots.allowed(self._client, url):
+            raise PermissionError(f"Robots disallow fetching {url}")
+
+        response = await self._request("GET", url, **kwargs)
+        if response.status_code == 304 and cached:
+            self._log_audit(url, response.status_code, len(cached.content), "cache-hit")
+            return httpx.Response(200, headers=cached.headers, content=cached.content)
+
+        if use_cache and response.status_code == 200:
+            self.cache.set(
+                url,
+                CachedResponse(
+                    status_code=response.status_code,
+                    headers=dict(response.headers),
+                    content=response.content,
+                    timestamp=time.time(),
+                ),
+            )
+        self._log_audit(url, response.status_code, len(response.content), "fetched")
+        return response
+
+    async def head(self, url: str, **kwargs) -> httpx.Response:
+        if not await self.robots.allowed(self._client, url):
+            raise PermissionError(f"Robots disallow fetching {url}")
+        response = await self._request("HEAD", url, **kwargs)
+        self._log_audit(url, response.status_code, 0, "head")
+        return response
+
+    def _log_audit(self, url: str, status_code: int, size: int, decision: str) -> None:
+        if not self.audit_path or not self.adapter_name:
+            return
+        try:
+            from .audit import record_request
+
+            record_request(
+                adapter=self.adapter_name,
+                url=url,
+                status_code=status_code,
+                bytes_count=size,
+                decision=decision,
+                path=self.audit_path,
+            )
+        except Exception:
+            logger.exception("Failed to record audit entry for %s", url)
+
+    async def __aenter__(self) -> "AsyncHttpClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()

--- a/crawler/core/models.py
+++ b/crawler/core/models.py
@@ -1,0 +1,66 @@
+"""Data models for normalized crawler output."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class Kind(str, Enum):
+    """Kinds of records supported by the crawler."""
+
+    DOCUMENT = "docs"
+    MOVIE = "movies"
+    PRICE = "prices"
+    ALL = "all"
+
+    @classmethod
+    def for_output(cls, value: str) -> "Kind":
+        try:
+            return cls(value)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported kind: {value}") from exc
+
+
+class MediaType(str, Enum):
+    PDF = "pdf"
+    VIDEO = "video"
+    PAGE = "page"
+    PRODUCT = "product"
+
+
+class Record(BaseModel):
+    """Normalized representation of crawler results."""
+
+    id: str
+    kind: Kind
+    title: str
+    description: Optional[str] = None
+    creators: Optional[List[str]] = None
+    year: Optional[int] = None
+    language: Optional[str] = None
+    topics: Optional[List[str]] = None
+    provider: str
+    source_url: HttpUrl
+    license: Optional[str] = None
+    media: Dict[str, Any] = Field(default_factory=dict)
+    availability: Dict[str, Any] = Field(default_factory=dict)
+    price: Dict[str, Any] = Field(default_factory=dict)
+    extra: Dict[str, Any] = Field(default_factory=dict)
+    ingested_at: datetime
+
+
+
+class AuditEntry(BaseModel):
+    """Structured audit log entry."""
+
+    timestamp: datetime
+    adapter: str
+    url: HttpUrl
+    status_code: int
+    bytes: int
+    decision: str
+    notes: Optional[str] = None

--- a/crawler/core/pipeline.py
+++ b/crawler/core/pipeline.py
@@ -1,0 +1,68 @@
+"""Orchestration pipeline for crawling and normalizing records."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Iterable, List, Sequence
+
+from ..adapters.base import BaseAdapter
+from ..settings import AppSettings
+from .models import Kind, Record
+from .utils import stable_hash
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_adapter(adapter: BaseAdapter, query: str, limit: int) -> List[Record]:
+    results: List[Record] = []
+    try:
+        discovered = await adapter.discover(query)
+        for url in discovered[:limit]:
+            raw = await adapter.fetch(url)
+            parsed = await adapter.parse(raw)
+            for item in parsed:
+                if len(results) >= limit:
+                    break
+                results.append(item)
+            if len(results) >= limit:
+                break
+    except Exception:
+        logger.exception("Adapter %s failed", adapter.name)
+    return results
+
+
+def deduplicate(records: Sequence[Record]) -> List[Record]:
+    seen = {}
+    deduped: List[Record] = []
+    for record in records:
+        key = (record.kind, record.provider, record.title.lower(), record.year, record.price.get("sku"))
+        stable = stable_hash(key)
+        if stable in seen:
+            continue
+        seen[stable] = True
+        deduped.append(record)
+    return deduped
+
+
+async def crawl(*, kind: Kind, query: str, limit: int, settings: AppSettings) -> List[Record]:
+    adapters = [adapter for adapter in settings.instantiate_adapters() if adapter.supports_kind(kind)]
+    adapter_limit = max(1, limit // max(1, len(adapters)))
+
+    tasks = [asyncio.create_task(_run_adapter(adapter, query, adapter_limit)) for adapter in adapters]
+    results: List[Record] = []
+    for task in asyncio.as_completed(tasks):
+        records = await task
+        results.extend(records)
+
+    deduped = deduplicate(results)
+    limited = deduped[:limit]
+    now = datetime.utcnow()
+    for record in limited:
+        record.ingested_at = now
+    return limited
+
+
+def crawl_sync(kind: Kind, query: str, limit: int, settings: AppSettings) -> Iterable[Record]:
+    return asyncio.run(crawl(kind=kind, query=query, limit=limit, settings=settings))

--- a/crawler/core/storage.py
+++ b/crawler/core/storage.py
@@ -1,0 +1,97 @@
+"""Storage utilities for persisting crawler results."""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import sqlite3
+
+from .models import Record
+from .utils import ensure_dir
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OutputSettings:
+    sqlite_path: str = "data/results.db"
+    jsonl_path: str = "data/results.jsonl"
+
+
+class ResultWriter(AbstractContextManager):
+    """Context manager that writes records to JSONL and SQLite."""
+
+    def __init__(self, settings: OutputSettings) -> None:
+        self.settings = settings
+        self.jsonl_path = Path(settings.jsonl_path)
+        self.sqlite_path = Path(settings.sqlite_path)
+        ensure_dir(self.jsonl_path.parent)
+        ensure_dir(self.sqlite_path.parent)
+        self._jsonl_file = None
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def __enter__(self) -> "ResultWriter":
+        self._jsonl_file = self.jsonl_path.open("a", encoding="utf-8")
+        self._conn = sqlite3.connect(self.sqlite_path)
+        self._apply_migrations()
+        return self
+
+    def _apply_migrations(self) -> None:
+        assert self._conn is not None
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS records (
+                id TEXT PRIMARY KEY,
+                kind TEXT,
+                title TEXT,
+                description TEXT,
+                data JSON,
+                created_at TEXT
+            )
+            """
+        )
+        self._conn.commit()
+
+    def write_record(self, record: Record) -> None:
+        payload = json.loads(record.json())
+        line = json.dumps(payload, ensure_ascii=False)
+        assert self._jsonl_file is not None and self._conn is not None
+        self._jsonl_file.write(line + "\n")
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO records (id, kind, title, description, data, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.id,
+                record.kind.value,
+                record.title,
+                record.description,
+                json.dumps(payload, ensure_ascii=False),
+                datetime.utcnow().isoformat(),
+            ),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._jsonl_file:
+            self._jsonl_file.close()
+        if self._conn:
+            self._conn.close()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+def write_records(records: Iterable[Record], settings: OutputSettings) -> None:
+    with ResultWriter(settings) as writer:
+        for record in records:
+            writer.write_record(record)

--- a/crawler/core/utils.py
+++ b/crawler/core/utils.py
@@ -1,0 +1,55 @@
+"""Utility helpers for the crawler."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from difflib import SequenceMatcher
+
+SLUGIFY_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def stable_hash(value: object) -> str:
+    """Create a deterministic hash for the given value."""
+
+    serialized = json.dumps(value, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def slugify(value: str) -> str:
+    """Return a simple slug for filenames/logging."""
+
+    value = value.lower()
+    value = SLUGIFY_PATTERN.sub("-", value).strip("-")
+    return value or "item"
+
+
+def now_iso() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def fuzzy_equal(a: str, b: str, threshold: float = 0.8) -> bool:
+    """Return True if strings are sufficiently similar."""
+
+    ratio = SequenceMatcher(a=a.lower(), b=b.lower()).ratio()
+    return ratio >= threshold
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def batched(iterable: Iterable, size: int):
+    batch = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) == size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch

--- a/crawler/settings.py
+++ b/crawler/settings.py
@@ -1,0 +1,71 @@
+"""Application configuration using Pydantic settings."""
+
+from __future__ import annotations
+
+import json
+import logging
+from importlib import import_module
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Type
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency for config files
+    yaml = None
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .adapters.base import BaseAdapter
+from .core.storage import OutputSettings
+
+logger = logging.getLogger(__name__)
+
+
+class ConcurrencySettings(BaseModel):
+    global_max_tasks: int = 20
+    per_domain_rps: float = 1.5
+
+
+class AdapterConfig(BaseModel):
+    name: str
+    options: Dict[str, object] = Field(default_factory=dict)
+
+
+class FiltersConfig(BaseModel):
+    language: List[str] = Field(default_factory=list)
+    min_year: Optional[int] = None
+
+
+class AppOutputSettings(OutputSettings):
+    pass
+
+
+class AppSettings(BaseSettings):
+    user_agent: str = "MyCrawler/1.0 (+contact@example.com)"
+    cache_dir: str = ".cache"
+    concurrency: ConcurrencySettings = ConcurrencySettings()
+    adapters: Sequence[AdapterConfig] = Field(default_factory=list)
+    filters: FiltersConfig = FiltersConfig()
+    output: AppOutputSettings = AppOutputSettings()
+
+    model_config = SettingsConfigDict(env_prefix="CRAWLER_", arbitrary_types_allowed=True)
+
+    def instantiate_adapters(self) -> List[BaseAdapter]:
+        instances: List[BaseAdapter] = []
+        for config in self.adapters:
+            module = import_module(f"crawler.adapters.{config.name}")
+            adapter_cls: Type[BaseAdapter] = getattr(module, "Adapter")
+            instances.append(adapter_cls(settings=config.options | {"app_settings": self}))
+        return instances
+
+
+def load_settings(path: Optional[Path] = None) -> AppSettings:
+    data = {}
+    if path and path.exists():
+        logger.info("Loading configuration from %s", path)
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to load configuration files")
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    return AppSettings(**data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "python-web-crawler"
+version = "0.1.0"
+description = "Modular, policy-compliant Python web crawler"
+authors = [{ name = "Example", email = "contact@example.com" }]
+requires-python = ">=3.11"
+dependencies = [
+    "httpx[http2]",
+    "aiolimiter",
+    "pydantic>=2.0",
+    "pydantic-settings>=2.0",
+    "typer>=0.9",
+    "PyYAML",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "respx",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from crawler.core.models import Kind, Record
+from crawler.core.pipeline import deduplicate
+
+
+def build_record(title: str, sku: str | None = None) -> Record:
+    return Record(
+        id=title,
+        kind=Kind.DOCUMENT,
+        title=title,
+        description=None,
+        creators=None,
+        year=2020,
+        language="en",
+        topics=None,
+        provider="adapter",
+        source_url="https://example.com",
+        license=None,
+        media={},
+        availability={},
+        price={"sku": sku} if sku else {},
+        extra={},
+        ingested_at=datetime.utcnow(),
+    )
+
+
+def test_deduplicate_merges_similar_records():
+    records = [build_record("Title", None), build_record("Title", None)]
+    result = deduplicate(records)
+    assert len(result) == 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pytest
+
+from crawler.core.models import Kind, Record
+from crawler.core.pipeline import crawl
+from crawler.settings import AppSettings, AdapterConfig
+
+
+class DummyAdapter:
+    name = "dummy"
+    kinds = (Kind.DOCUMENT,)
+
+    def __init__(self, *, settings: Dict[str, Any] | None = None) -> None:
+        self.settings = settings or {}
+
+    async def discover(self, query: str) -> List[str]:
+        return [f"http://example.com/{query}"]
+
+    async def fetch(self, url: str) -> Dict[str, Any]:
+        return {"url": url}
+
+    async def parse(self, raw: Dict[str, Any]) -> List[Record]:
+        return [
+            Record(
+                id="dummy",
+                kind=Kind.DOCUMENT,
+                title="Example",
+                description="",
+                creators=None,
+                year=None,
+                language="en",
+                topics=None,
+                provider=self.name,
+                source_url="https://example.com",
+                license="Public Domain",
+                media={"type": "pdf"},
+                availability={"is_free": True},
+                price={},
+                extra={"raw": raw},
+                ingested_at=datetime.utcnow(),
+            )
+        ]
+
+    def supports_kind(self, kind: Kind) -> bool:
+        return kind in self.kinds
+
+
+@pytest.mark.asyncio
+async def test_crawl_uses_adapters(monkeypatch):
+    settings = AppSettings(adapters=[AdapterConfig(name="dummy", options={})])
+
+    def fake_instantiate(self):
+        return [DummyAdapter()]
+
+    monkeypatch.setattr(AppSettings, "instantiate_adapters", fake_instantiate)
+
+    records = await crawl(kind=Kind.DOCUMENT, query="test", limit=10, settings=settings)
+    assert len(records) == 1
+    assert records[0].provider == "dummy"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+from crawler.core import utils
+
+
+def test_stable_hash_changes_with_input():
+    value1 = utils.stable_hash({"a": 1})
+    value2 = utils.stable_hash({"a": 2})
+    assert value1 != value2
+
+
+def test_fuzzy_equal():
+    assert utils.fuzzy_equal("Example", "example")
+    assert not utils.fuzzy_equal("Example", "Different", threshold=0.9)

--- a/tests/test_youtube_duration.py
+++ b/tests/test_youtube_duration.py
@@ -1,0 +1,7 @@
+from crawler.adapters.youtube_free import _parse_iso_duration
+
+
+def test_parse_iso_duration():
+    assert _parse_iso_duration("PT1H2M3S") == 3723
+    assert _parse_iso_duration("PT45M") == 2700
+    assert _parse_iso_duration(None) == 0


### PR DESCRIPTION
## Summary
- add application settings, HTTP client with caching/rate limits, and audit logging utilities
- implement adapter framework with initial Internet Archive, CKAN, TMDB, YouTube, and retailer adapters plus CLI and storage layers
- document usage with README/config sample and add pytest suite covering pipeline, utilities, and duration parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df24e5364c83249163cf6bc3bf11ea